### PR TITLE
Wasmfixes

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -92,8 +92,8 @@ pub fn build(b: *std.Build) void {
 
         emcc.addArgs(&.{
             "--shell-file",
-            b.path("src/shell.html").getPath(b),
         });
+        emcc.addFileArg(b.path("src/shell.html"));
 
         //emcc.addArg("--pre-js");
         emcc.addArg("-o");

--- a/build.zig
+++ b/build.zig
@@ -104,18 +104,16 @@ pub fn build(b: *std.Build) void {
             .install_subdir = "",
         }).step);
 
-        const run_emrun = b.addSystemCommand(&.{"emrun"});
-
-        run_emrun.addArg(b.pathJoin(&.{ b.install_path, "www", "breakout.html" }));
-
-        run_emrun.addArgs(&.{
-            "--browser=/mnt/c/Program Files/Google/Chrome/Application/chrome.exe",
-        });
-
-        if (b.args) |args| run_emrun.addArgs(args);
-        run_emrun.step.dependOn(b.getInstallStep());
-        const run_step = b.step("run", "Run the app");
-
-        run_step.dependOn(&run_emrun.step);
+        // const run_emrun = b.addSystemCommand(&.{"emrun"});
+        // run_emrun.addArg(b.pathJoin(&.{ b.install_path, "www", "breakout.html" }));
+        // run_emrun.addArgs(&.{
+        //     "--browser=/mnt/c/Program Files/Google/Chrome/Application/chrome.exe",
+        // });
+        //
+        // if (b.args) |args| run_emrun.addArgs(args);
+        // run_emrun.step.dependOn(b.getInstallStep());
+        //
+        // const run_step = b.step("run", "Run the app");
+        // run_step.dependOn(&run_emrun.step);
     }
 }

--- a/build.zig
+++ b/build.zig
@@ -1,4 +1,15 @@
 const std = @import("std");
+fn addAssets(b: *std.Build, exe: *std.Build.Step.Compile) void {
+    const assets = [_][]const u8{
+        "res/paddle.png",
+        "res/tennis.png",
+        "res/brick.png",
+    };
+
+    for (assets) |asset| {
+        exe.root_module.addAnonymousImport(asset, .{ .root_source_file = b.path(asset) });
+    }
+}
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
@@ -31,15 +42,7 @@ pub fn build(b: *std.Build) void {
             .install_subdir = "res",
         });
         exe.step.dependOn(&install_step.step);
-        const assets = [_][]const u8{
-            "res/paddle.png",
-            "res/tennis.png",
-            "res/brick.png",
-        };
-
-        for (assets) |asset| {
-            exe.root_module.addAnonymousImport(asset, .{ .root_source_file = b.path(asset) });
-        }
+        addAssets(b, exe);
 
         b.installArtifact(exe);
 
@@ -77,6 +80,7 @@ pub fn build(b: *std.Build) void {
             .root_module = exe_mod,
         });
         app_lib.linkLibrary(raylib_artifact);
+        addAssets(b, app_lib);
 
         const emcc = b.addSystemCommand(&.{"emcc"});
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -37,8 +37,8 @@
     // internet connectivity.
     .dependencies = .{
         .raylib = .{
-            .url = "git+https://github.com/raysan5/raylib/?ref=HEAD#80fcca4155fde407b1551721b6271f9a1fe527d3",
-            .hash = "raylib-5.5.0-whq8uPuyNARF5oIcIW5D0fNHVw_Zg6dB6q0DhTSjKGr-",
+            .url = "git+https://github.com/raysan5/raylib#27a4fe885164b315a90b67682f981a1e03d6079c",
+            .hash = "raylib-5.5.0-whq8uFqtNARw6t1tTakBDSVYgUjlBqnDppOyNfE_yfCa",
         },
     },
     .paths = .{

--- a/src/main.zig
+++ b/src/main.zig
@@ -19,6 +19,7 @@ pub fn main() !void {
         _ = debug_allocator.deinit();
     };
 
+    r.SetConfigFlags(r.FLAG_VSYNC_HINT | r.FLAG_WINDOW_RESIZABLE);
     r.InitWindow(engine.W_W, engine.W_H, "breakout");
     defer r.CloseWindow();
 

--- a/src/shell.html
+++ b/src/shell.html
@@ -340,6 +340,13 @@ jwE50AGjLCVuS8Yt4H7OgZLKK5EKOsLviEWJSL/+0uMi7gLUSBseYwqEbXvSHCec1CJvZPyHCmYQffaB
             },
             false,
           );
+          canvas.addEventListener("keydown", (e) => {
+            if(["Space","ArrowUp","ArrowDown","ArrowLeft","ArrowRight","F1","F3","F5"].indexOf(e.code) > -1) {
+              e.preventDefault();
+            }
+          }, false);
+          canvas.scrollIntoView({behavior: "smooth"});
+          canvas.focus();
 
           return canvas;
         })(),


### PR DESCRIPTION
A bunch of changes to make it work with emscripten.
To compile it use a command like:
```
zig build -Doptimize=ReleaseFast -Dtarget=wasm32-emscripten --sysroot "/home/sze/development/workspace/c/emsdk/upstream/emscripten"
```
With the `--sysroot`/emsdk-path updated to point to your local emsdk installation, in a future pull request we can change it so that the emscripten dependency from raylib will be used automatically, but that requires some more changes to raylib's build.zig.

Some of the commits have individual detail descriptions.